### PR TITLE
resource aws_iam_role_policy_attachment ebs_csi_node {

### DIFF
--- a/terraform/eks/iam.tf
+++ b/terraform/eks/iam.tf
@@ -268,3 +268,8 @@ resource "aws_iam_role_policy" "eks_admin_policy" {
     ]
   })
 }
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_node" {
+  role       = aws_iam_role.eks_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEBSCSIDriverPolicy"
+}


### PR DESCRIPTION
  role       = aws_iam_role.eks_node_role.name
  policy_arn = arn:aws:iam::aws:policy/AmazonEBSCSIDriverPolicy
}